### PR TITLE
Simplification when updating a token/subscription. 

### DIFF
--- a/meta/argument_specs.yml
+++ b/meta/argument_specs.yml
@@ -40,6 +40,7 @@ argument_specs:
           - attached
           - detached
           - present
+          - update
         default: present
       ubuntu_pro_token:
         description:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -11,9 +11,13 @@
   include_tasks: configure.yml
   when: state == 'present' or state == 'attached'
 
+- name: Include tasks 'unregister.yml'
+  include_tasks: unregister.yml
+  when: state == 'absent' or state == 'detached' or state == 'update'
+
 - name: Include tasks 'register.yml'
   include_tasks: register.yml
-  when: state == 'present' or state == 'attached'
+  when: state == 'present' or state == 'attached' or state == 'update'
 
 - name: Include tasks 'enable_services.yml'
   include_tasks: enable_services.yml


### PR DESCRIPTION
When you need to update a token, a detach is needed. ATM; to do that, you had to run the role twice, detach then attach. I've added an 'update' state to deal with this in one run. The unregister is executed before the register if' update' is enabled.